### PR TITLE
Adds From<&str> for Title

### DIFF
--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -1433,6 +1433,12 @@ pub struct Title {
     pad: Option<Pad>,
 }
 
+impl From<&str> for Title {
+    fn from(title: &str) -> Self {
+        Self::new(title.into())
+    }
+}
+
 impl Title {
     pub fn new(text: &str) -> Title {
         Title {


### PR DESCRIPTION
This enables one to write code like
```rust
let layout = plotly::layout::Layout::new().title("Overview plot".into());
```
Which could be nice to have.